### PR TITLE
fix(site): build error

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -28,10 +28,6 @@ module.exports = {
             name: 'guides-crawler',
             rootDir: path.resolve(__dirname, '../docs'),
           },
-          {
-            name: 'guides-crawler',
-            rootDir: path.resolve(__dirname, '../docs/overview'),
-          },
         ],
         // 为每个文档添加元数据：它属于哪个类目
         // 每个文档都需要有一个类目，文档的访问路径就是`/类目name/文档name`
@@ -120,6 +116,7 @@ module.exports = {
           // path.resolve(__dirname, '../../../node_modules'),
           'node_modules',
         ],
+        dynamicDocs: []
       },
     },
   ],

--- a/site/package.json
+++ b/site/package.json
@@ -9,16 +9,19 @@
     "develop": "npm run clean && gatsby develop",
     "start": "npm run develop",
     "debug": "npm run clean && npx --node-arg=--inspect-brk gatsby develop",
-    "build": "npm run clean && gatsby build --prefix-paths"
+    "build": "npm run clean && gatsby build --prefix-paths",
+    "postinstall": "rm -rf ./node_modules/gatsby/node_modules/gatsby-cli"
   },
   "devDependencies": {
     "@alicloud/gatsby-theme-console-doc": "^1.0.5",
-    "gatsby": "^2.18.2",
+    "gatsby": "2.19.45",
+    "gatsby-cli": "2.10.11",
     "gh-pages": "^2.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "styled-components": "^4.4.1",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "webpack-virtual-modules": "^0.2.2"
   },
   "dependencies": {
     "@alicloud/console-chart": "^0.1.0-alpha.4"


### PR DESCRIPTION
最新版本的gatsby有bug，所以需要暂时锁定2个版本：
- gatsby-cli@2.10.11
- gatsby@2.19.45

gatsby太重了，经常出现莫名其妙的bug，开发启动和构建都很慢。我正在干掉gatsby，用vite代替。文档框架更新以后我会帮你迁移。